### PR TITLE
update .gitignore to ignore macOS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# macOS
+.DS_Store


### PR DESCRIPTION
Hello team,

Cette pull request met simplement à jour le `.gitignore` pour éviter de traquer les fichiers spécifiques à macOS (`.DS_Store`).

Je ne participe pas directement au vote pour éviter toute confusion : l’objectif est juste de simplifier la gestion du repo et d’éviter que des fichiers inutiles apparaissent dans les prochains commits.

C’est une modification purement "qualité de vie", sans impact sur le code ou les données.